### PR TITLE
Optimized PWM_DEAD_TIME, fixed duty cylcle for MOTOR_PWM_MANIP_HIGH

### DIFF
--- a/firmware/src/motor/realtime/motor_pwm.c
+++ b/firmware/src/motor/realtime/motor_pwm.c
@@ -47,7 +47,7 @@
 # error "Invalid timer clock"
 #endif
 
-#define PWM_DEAD_TIME_NANOSEC   400
+#define PWM_DEAD_TIME_NANOSEC   750
 
 /**
  * Local constants, initialized once
@@ -362,7 +362,7 @@ void motor_pwm_manip(const enum motor_pwm_phase_manip command[MOTOR_NUM_PHASES])
 	for (int phase = 0; phase < MOTOR_NUM_PHASES; phase++) {
 		if (command[phase] == MOTOR_PWM_MANIP_HIGH) {
 			// We don't want to engage 100% duty cycle because the high side pump needs switching
-			const int pwm_val = motor_pwm_compute_pwm_val(0.90f);
+			const int pwm_val = motor_pwm_compute_pwm_val(0.80f);
 			irq_primask_disable();
 			phase_set_i(phase, pwm_val, false);
 			irq_primask_enable();


### PR DESCRIPTION
Reduced heat generation when running on higher voltages (tested up to 4s).
Fixes #3
