### PR TITLE
Improved spinup sequence for beta v2.0

### DIFF
--- a/firmware/src/motor/motor.c
+++ b/firmware/src/motor/motor.c
@@ -112,7 +112,7 @@ static struct params
 
 
 CONFIG_PARAM_FLOAT("mot_v_min",        2.5,    0.5,     10.0)
-CONFIG_PARAM_FLOAT("mot_v_spinup",     0.1,    0.01,    10.0)
+CONFIG_PARAM_FLOAT("mot_v_spinup",     0.5,    0.01,    10.0)
 CONFIG_PARAM_FLOAT("mot_spup_vramp_t", 3.0,    0.0,     10.0)
 CONFIG_PARAM_FLOAT("mot_dc_accel",     0.09,   0.001,   0.5)
 CONFIG_PARAM_FLOAT("mot_dc_slope",     5.0,    0.1,     20.0)

--- a/firmware/src/motor/motor.c
+++ b/firmware/src/motor/motor.c
@@ -111,7 +111,7 @@ static struct params
 } _params;
 
 
-CONFIG_PARAM_FLOAT("mot_v_min",        3.0,    0.5,     10.0)
+CONFIG_PARAM_FLOAT("mot_v_min",        2.5,    0.5,     10.0)
 CONFIG_PARAM_FLOAT("mot_v_spinup",     0.1,    0.0,     10.0)
 CONFIG_PARAM_FLOAT("mot_spup_vramp_t", 3.0,    0.0,     10.0)
 CONFIG_PARAM_FLOAT("mot_dc_accel",     0.09,   0.001,   0.5)

--- a/firmware/src/motor/motor.c
+++ b/firmware/src/motor/motor.c
@@ -112,7 +112,7 @@ static struct params
 
 
 CONFIG_PARAM_FLOAT("mot_v_min",        2.5,    0.5,     10.0)
-CONFIG_PARAM_FLOAT("mot_v_spinup",     0.1,    0.0,     10.0)
+CONFIG_PARAM_FLOAT("mot_v_spinup",     0.1,    0.01,    10.0)
 CONFIG_PARAM_FLOAT("mot_spup_vramp_t", 3.0,    0.0,     10.0)
 CONFIG_PARAM_FLOAT("mot_dc_accel",     0.09,   0.001,   0.5)
 CONFIG_PARAM_FLOAT("mot_dc_slope",     5.0,    0.1,     20.0)

--- a/firmware/src/motor/realtime/adc.h
+++ b/firmware/src/motor/realtime/adc.h
@@ -44,6 +44,7 @@ extern "C" {
 
 extern const int MOTOR_ADC_SYNC_ADVANCE_NANOSEC;
 extern const int MOTOR_ADC_SAMPLE_WINDOW_NANOSEC;
+extern const int MOTOR_ADC_MIN_BLANKING_TIME_NANOSEC;
 
 
 struct motor_adc_sample

--- a/firmware/src/motor/realtime/motor_adc.c
+++ b/firmware/src/motor/realtime/motor_adc.c
@@ -81,8 +81,6 @@ static struct motor_adc_sample _sample;
 __attribute__((optimize(3)))
 CH_FAST_IRQ_HANDLER(Vector88)	// ADC1 + ADC2 handler
 {
-	TESTPAD_SET(GPIO_PORT_TEST_A, GPIO_PIN_TEST_A);
-
 	_sample.timestamp = motor_timer_hnsec() -
 		((SAMPLE_DURATION_NANOSEC * NUM_SAMPLES_PER_ADC) / 2) / NSEC_PER_HNSEC;
 
@@ -102,8 +100,6 @@ CH_FAST_IRQ_HANDLER(Vector88)	// ADC1 + ADC2 handler
 
 #undef SMPLADC1
 #undef SMPLADC2
-
-	TESTPAD_CLEAR(GPIO_PORT_TEST_A, GPIO_PIN_TEST_A);
 
 	motor_adc_sample_callback(&_sample);
 

--- a/firmware/src/motor/realtime/motor_adc.c
+++ b/firmware/src/motor/realtime/motor_adc.c
@@ -66,7 +66,7 @@ const int MOTOR_ADC_SAMPLE_WINDOW_NANOSEC = SAMPLE_DURATION_NANOSEC * NUM_SAMPLE
  * This parameter is dictated by the phase voltage RC filters.
  * Higher oversampling allows for a lower blanking time, due to stronger averaging.
  */
-const int MOTOR_ADC_MIN_BLANKING_TIME_NANOSEC = 1500;
+const int MOTOR_ADC_MIN_BLANKING_TIME_NANOSEC = 2000;
 
 
 CONFIG_PARAM_FLOAT("mot_i_shunt_mr",         5.0,   0.1,   100.0)

--- a/firmware/src/motor/realtime/motor_adc.c
+++ b/firmware/src/motor/realtime/motor_adc.c
@@ -63,6 +63,12 @@ const int MOTOR_ADC_SYNC_ADVANCE_NANOSEC = 0;
 
 const int MOTOR_ADC_SAMPLE_WINDOW_NANOSEC = SAMPLE_DURATION_NANOSEC * NUM_SAMPLES_PER_ADC;
 
+/**
+ * This parameter is dictated by the phase voltage RC filters.
+ * Higher oversampling allows for a lower blanking time, due to stronger averaging.
+ */
+const int MOTOR_ADC_MIN_BLANKING_TIME_NANOSEC = 2000;
+
 
 CONFIG_PARAM_FLOAT("mot_i_shunt_mr",         5.0,   0.1,   100.0)
 
@@ -76,6 +82,8 @@ static struct motor_adc_sample _sample;
 __attribute__((optimize(3)))
 CH_FAST_IRQ_HANDLER(Vector88)	// ADC1 + ADC2 handler
 {
+	TESTPAD_SET(GPIO_PORT_TEST_A, GPIO_PIN_TEST_A);
+
 	_sample.timestamp = motor_timer_hnsec() -
 		((SAMPLE_DURATION_NANOSEC * NUM_SAMPLES_PER_ADC) / 2) / NSEC_PER_HNSEC;
 
@@ -95,6 +103,8 @@ CH_FAST_IRQ_HANDLER(Vector88)	// ADC1 + ADC2 handler
 
 #undef SMPLADC1
 #undef SMPLADC2
+
+	TESTPAD_CLEAR(GPIO_PORT_TEST_A, GPIO_PIN_TEST_A);
 
 	motor_adc_sample_callback(&_sample);
 

--- a/firmware/src/motor/realtime/motor_adc.c
+++ b/firmware/src/motor/realtime/motor_adc.c
@@ -47,7 +47,7 @@
 #define ADC_REF_VOLTAGE          3.3f
 #define ADC_RESOLUTION           12
 
-#define NUM_SAMPLES_PER_ADC      4
+#define NUM_SAMPLES_PER_ADC      2
 
 /**
  * One ADC sample at maximum speed takes 14 cycles; max ADC clock at 72 MHz input is 12 MHz, so one ADC sample is:
@@ -58,7 +58,8 @@
 /**
  * ADC will be triggered at this time before the PWM mid cycle.
  */
-const int MOTOR_ADC_SYNC_ADVANCE_NANOSEC = (SAMPLE_DURATION_NANOSEC * (NUM_SAMPLES_PER_ADC - 1)) / 2;
+//const int MOTOR_ADC_SYNC_ADVANCE_NANOSEC = (SAMPLE_DURATION_NANOSEC * (NUM_SAMPLES_PER_ADC - 1)) / 2;
+const int MOTOR_ADC_SYNC_ADVANCE_NANOSEC = 0;
 
 const int MOTOR_ADC_SAMPLE_WINDOW_NANOSEC = SAMPLE_DURATION_NANOSEC * NUM_SAMPLES_PER_ADC;
 
@@ -88,15 +89,23 @@ CH_FAST_IRQ_HANDLER(Vector88)	// ADC1 + ADC2 handler
 #define SMPLADC2(num)     (_adc1_2_dma_buffer[num] >> 16)
 	/*
 	 * ADC channel sampling:
-	 *   A A C VOLT
-	 *   C B B CURR
+	 *   A C
+	 *   B VOLT/CURR
 	 */
-	_sample.phase_values[0] = (SMPLADC1(0) + SMPLADC1(1)) / 2;
-	_sample.phase_values[1] = (SMPLADC2(1) + SMPLADC2(2)) / 2;
-	_sample.phase_values[2] = (SMPLADC2(0) + SMPLADC1(2)) / 2;
+	_sample.phase_values[0] = SMPLADC1(0);
+	_sample.phase_values[1] = SMPLADC2(0);
+	_sample.phase_values[2] = SMPLADC1(1);
 
-	_sample.input_voltage = SMPLADC1(3);
-	_sample.input_current = SMPLADC2(3);
+	// Voltage and current channels are alternating
+	if ((ADC2->SQR3 & ADC_SQR3_SQ2_0) != 0)
+	{
+		ADC2->SQR3 &= ~ADC_SQR3_SQ2_0;
+		_sample.input_current = SMPLADC2(1);
+	} else
+	{
+		ADC2->SQR3 |= ADC_SQR3_SQ2_0;
+		_sample.input_voltage = SMPLADC2(1);
+	}
 
 #undef SMPLADC1
 #undef SMPLADC2
@@ -154,22 +163,18 @@ static void enable(void)
 
 	/*
 	 * ADC channel sampling:
-	 *   A A C VOLT
-	 *   C B B CURR
+	 *   A C
+	 *   B VOLT/CURR
 	 */
-	ADC1->SQR1 = ADC_SQR1_L_0 | ADC_SQR1_L_1;
+	ADC1->SQR1 = ADC_SQR1_L_0;
 	ADC1->SQR3 =
-		ADC_SQR3_SQ1_0 |
-		ADC_SQR3_SQ2_0 |
-		ADC_SQR3_SQ3_0 | ADC_SQR3_SQ3_1 |
-		ADC_SQR3_SQ4_2;
+		ADC_SQR3_SQ1_0 |                     // A
+		ADC_SQR3_SQ2_0 | ADC_SQR3_SQ2_1;     // C
 
 	ADC2->SQR1 = ADC1->SQR1;
 	ADC2->SQR3 =
-		ADC_SQR3_SQ1_0 | ADC_SQR3_SQ1_1 |
-		ADC_SQR3_SQ2_1 |
-		ADC_SQR3_SQ3_1 |
-		ADC_SQR3_SQ4_2 | ADC_SQR3_SQ4_0;
+		ADC_SQR3_SQ1_1 |                     // B
+		ADC_SQR3_SQ2_2 | ADC_SQR3_SQ2_0;     // VOLT/CURR
 
 	// SMPR registers are not configured because they have right values by default
 

--- a/firmware/src/motor/realtime/motor_adc.c
+++ b/firmware/src/motor/realtime/motor_adc.c
@@ -67,7 +67,7 @@ const int MOTOR_ADC_SAMPLE_WINDOW_NANOSEC = SAMPLE_DURATION_NANOSEC * NUM_SAMPLE
  * This parameter is dictated by the phase voltage RC filters.
  * Higher oversampling allows for a lower blanking time, due to stronger averaging.
  */
-const int MOTOR_ADC_MIN_BLANKING_TIME_NANOSEC = 2000;
+const int MOTOR_ADC_MIN_BLANKING_TIME_NANOSEC = 7000;
 
 
 CONFIG_PARAM_FLOAT("mot_i_shunt_mr",         5.0,   0.1,   100.0)

--- a/firmware/src/motor/realtime/motor_adc.c
+++ b/firmware/src/motor/realtime/motor_adc.c
@@ -66,7 +66,7 @@ const int MOTOR_ADC_SAMPLE_WINDOW_NANOSEC = SAMPLE_DURATION_NANOSEC * NUM_SAMPLE
  * This parameter is dictated by the phase voltage RC filters.
  * Higher oversampling allows for a lower blanking time, due to stronger averaging.
  */
-const int MOTOR_ADC_MIN_BLANKING_TIME_NANOSEC = 5000;
+const int MOTOR_ADC_MIN_BLANKING_TIME_NANOSEC = 9000;
 
 
 CONFIG_PARAM_FLOAT("mot_i_shunt_mr",         5.0,   0.1,   100.0)

--- a/firmware/src/motor/realtime/motor_debug_cli.c
+++ b/firmware/src/motor/realtime/motor_debug_cli.c
@@ -109,6 +109,8 @@ void motor_rtctl_execute_cli_command(int argc, const char* argv[])
 		printf("PWM val: %d, pos: %d, neg: %d, flt: %d\n",
 		       pwm_val, step.positive, step.negative, step.floating);
 
+		motor_pwm_set_freewheeling();    // Pre-reset is required
+
 		irq_primask_disable();
 		motor_pwm_set_step_from_isr(&step, pwm_val);
 		irq_primask_enable();

--- a/firmware/src/motor/realtime/motor_debug_cli.c
+++ b/firmware/src/motor/realtime/motor_debug_cli.c
@@ -115,12 +115,6 @@ void motor_rtctl_execute_cli_command(int argc, const char* argv[])
 		motor_pwm_set_step_from_isr(&step, pwm_val);
 		irq_primask_enable();
 
-	} else if ((argc > 0) && !strcmp("2q", argv[0])) {
-		// Configure 2 quadrant mode
-		const bool enable = (argc > 1) ? (atoi(argv[1]) != 0) : false;
-		printf("2Q mode: %s\n", enable ? "ON" : "OFF");
-		motor_pwm_set_2_quadrant_mode(enable);
-
 	} else if ((argc >= 1) && (argc <= 3)) {
 		const enum motor_pwm_phase_manip manip_cmd[MOTOR_NUM_PHASES] = {
 			arg_to_pwm_manip(argv[0]),

--- a/firmware/src/motor/realtime/motor_pwm.c
+++ b/firmware/src/motor/realtime/motor_pwm.c
@@ -307,9 +307,9 @@ static inline void phase_set_i(uint_fast8_t phase, uint_fast16_t pwm_val, bool i
 	if (phase == 0) {
 		TIM1->CCR1 = pwm_val;
 		if (inverted) {
-			TIM1->CCMR1 |= TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_0;  // inverted
+			TIM1->CCMR1 |= TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_0;  // PWM mode 2 inverted
 		} else {
-			TIM1->CCMR1 |= TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC1M_1;                 // non inverted
+			TIM1->CCMR1 |= TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC1M_1;                 // PWM mode 1 non inverted
 		}
 		TIM1->CCER |= (TIM_CCER_CC1E | TIM_CCER_CC1NE);
 	} else if (phase == 1) {

--- a/firmware/src/motor/realtime/motor_pwm.c
+++ b/firmware/src/motor/realtime/motor_pwm.c
@@ -99,7 +99,7 @@ static int init_constants(unsigned frequency, const float pwm_dead_time_ns)
 	 */
 	const float pwm_clock_period = 1.f / PWM_TIMER_FREQUENCY;
 	const float pwm_min_duration =
-		(MOTOR_ADC_SAMPLE_WINDOW_NANOSEC + MOTOR_ADC_MIN_BLANKING_TIME_NANOSEC + pwm_dead_time_ns * 2.0F) /
+		(MOTOR_ADC_SAMPLE_WINDOW_NANOSEC + MOTOR_ADC_MIN_BLANKING_TIME_NANOSEC + pwm_dead_time_ns) /
 		1e9f;
 	const float pwm_min_ticks_float = pwm_min_duration / pwm_clock_period;
 	assert(pwm_min_ticks_float >= 0);
@@ -123,7 +123,7 @@ static int init_constants(unsigned frequency, const float pwm_dead_time_ns)
 	assert(adc_trigger_advance_ticks_float < (_pwm_top * 0.4f));
 	_adc_advance_ticks = (uint16_t)adc_trigger_advance_ticks_float;
 
-	const float adc_blanking = MOTOR_ADC_MIN_BLANKING_TIME_NANOSEC / 1e9f;
+	const float adc_blanking = (MOTOR_ADC_MIN_BLANKING_TIME_NANOSEC + pwm_dead_time_ns) / 1e9f;
 	_adc_blanking_ticks = (uint16_t)(adc_blanking / pwm_clock_period);
 
 	const float adc_sample_duration = MOTOR_ADC_SAMPLE_WINDOW_NANOSEC / 1e9f;

--- a/firmware/src/motor/realtime/motor_pwm.c
+++ b/firmware/src/motor/realtime/motor_pwm.c
@@ -52,7 +52,7 @@
 
 
 CONFIG_PARAM_INT("mot_pwm_hz",    30000, MOTOR_PWM_MIN_FREQUENCY, MOTOR_PWM_MAX_FREQUENCY)
-CONFIG_PARAM_INT("mot_pwm_dt_ns",   700,                     200,                     800)
+CONFIG_PARAM_INT("mot_pwm_dt_ns",   600,                     200,                     800)
 
 /**
  * Local constants, initialized once

--- a/firmware/src/motor/realtime/motor_rtctl.c
+++ b/firmware/src/motor/realtime/motor_rtctl.c
@@ -235,7 +235,7 @@ CONFIG_PARAM_INT("mot_comm_per_max",    12000, 5000,  50000)    // microsecond
 CONFIG_PARAM_INT("mot_spup_st_cp",      100000,10000, 300000)   // microsecond
 CONFIG_PARAM_INT("mot_spup_en_cp",      7000,  1000,  50000);   // microsecond
 CONFIG_PARAM_INT("mot_spup_to_ms",      5000,  100,   9000)     // millisecond (sic!)
-CONFIG_PARAM_INT("mot_spup_blnk_pm",    10,    1,     300)      // permill
+CONFIG_PARAM_INT("mot_spup_blnk_pm",    100,   1,     300)      // permill
 
 static void configure(void)
 {
@@ -851,7 +851,8 @@ void motor_adc_sample_callback(const struct motor_adc_sample* sample)
 		if (past_zc) {
 			// We may switch to the next phase without ever setting the prev_zc_timeout value
 			// in this commutation period!
-			// TODO the above might be the reason for 2Q-4Q hand-off failure!
+			// Advance angle should be around zero during spinup, otherwise synchronization can be
+			// lost quickly, especially if the rotor is loaded!
 			if (_state.spinup_bemf_integral > 0) {
 				const uint32_t new_comm_period = sample->timestamp - _state.prev_comm_timestamp;
 
@@ -881,7 +882,7 @@ void motor_adc_sample_callback(const struct motor_adc_sample* sample)
 					}
 				}
 			} else {
-				_state.spinup_bemf_integral += abs(bemf) * 2;
+				_state.spinup_bemf_integral += abs(bemf);
 			}
 		} else {
 			_state.spinup_bemf_integral -= abs(bemf);

--- a/firmware/src/motor/realtime/motor_rtctl.c
+++ b/firmware/src/motor/realtime/motor_rtctl.c
@@ -230,7 +230,7 @@ CONFIG_PARAM_INT("mot_tim_cp_min",      600,   100,   50000)    // microsecond
 CONFIG_PARAM_INT("mot_blank_usec",      40,    10,    300)      // microsecond
 CONFIG_PARAM_INT("mot_bemf_win_den",    4,     3,     8)        // dimensionless
 CONFIG_PARAM_INT("mot_bemf_range",      90,    10,    100)      // percent
-CONFIG_PARAM_INT("mot_zc_fails_max",    40,    6,     300)      // dimensionless
+CONFIG_PARAM_INT("mot_zc_fails_max",    30,    6,     300)      // dimensionless
 CONFIG_PARAM_INT("mot_comm_per_max",    3000,  1000,  15000)    // microsecond
 // Spinup settings
 CONFIG_PARAM_INT("mot_spup_st_cp",      100000,10000, 300000)   // microsecond

--- a/firmware/src/motor/realtime/motor_rtctl.c
+++ b/firmware/src/motor/realtime/motor_rtctl.c
@@ -966,6 +966,8 @@ void motor_rtctl_start(float initial_duty_cycle, float target_duty_cycle,
 	 */
 	chSysSuspend();
 
+	TESTPAD_SET(GPIO_PORT_TEST_A, GPIO_PIN_TEST_A);   // Spin up indicator
+
 	if ((spinup_ramp_duration > 0.0F) && (initial_duty_cycle < target_duty_cycle)) {
 		_state.pwm_val_before_spinup = motor_pwm_compute_pwm_val(initial_duty_cycle);
 		_state.pwm_val_after_spinup  = motor_pwm_compute_pwm_val(target_duty_cycle);
@@ -1054,6 +1056,8 @@ void motor_rtctl_start(float initial_duty_cycle, float target_duty_cycle,
 #else
 	motor_timer_set_relative(_state.comm_period / 2);
 #endif
+
+	TESTPAD_CLEAR(GPIO_PORT_TEST_A, GPIO_PIN_TEST_A);  // Spin up indicator
 
 	chSysEnable();
 

--- a/firmware/src/motor/realtime/motor_rtctl.c
+++ b/firmware/src/motor/realtime/motor_rtctl.c
@@ -297,6 +297,7 @@ static void stop_from_isr(void)
 	_state.flags = 0;
 	motor_timer_cancel();
 	motor_pwm_set_freewheeling();
+	motor_pwm_set_2_quadrant_mode(false);
 }
 
 static void engage_current_comm_step(void)
@@ -908,6 +909,7 @@ void motor_adc_sample_callback(const struct motor_adc_sample* sample)
 				if (_state.comm_period <= _params.spinup_end_comm_period) {
 					if (_state.pwm_val >= _state.pwm_val_after_spinup) {
 						_state.flags &= ~FLAG_SPINUP;
+						motor_pwm_set_2_quadrant_mode(false);
 					} else {
 						// Speed up the ramp a bit in order to converge faster
 						_state.pwm_val++;
@@ -981,6 +983,8 @@ void motor_rtctl_start(float initial_duty_cycle, float target_duty_cycle,
 
 	init_adc_filters();
 
+	motor_pwm_set_2_quadrant_mode(true);
+
 	/*
 	 * Start the background IRQ-driven process
 	 */
@@ -1025,6 +1029,8 @@ void motor_rtctl_stop(void)
 	irq_primask_enable();
 
 	motor_pwm_set_freewheeling();
+
+	motor_pwm_set_2_quadrant_mode(false);
 }
 
 void motor_rtctl_set_duty_cycle(float duty_cycle)

--- a/firmware/src/motor/realtime/motor_rtctl.c
+++ b/firmware/src/motor/realtime/motor_rtctl.c
@@ -226,7 +226,7 @@ CONFIG_PARAM_INT("mot_tim_adv_max",     15,    0,     29)       // electrical de
 CONFIG_PARAM_INT("mot_tim_cp_max",      300,   100,   50000)    // microsecond
 CONFIG_PARAM_INT("mot_tim_cp_min",      600,   100,   50000)    // microsecond
 // Most important parameters
-CONFIG_PARAM_INT("mot_blank_usec",      40,    10,    100)      // microsecond
+CONFIG_PARAM_INT("mot_blank_usec",      40,    10,    300)      // microsecond
 CONFIG_PARAM_INT("mot_bemf_win_den",    4,     3,     8)        // dimensionless
 CONFIG_PARAM_INT("mot_bemf_range",      90,    10,    100)      // percent
 CONFIG_PARAM_INT("mot_zc_fails_max",    40,    6,     300)      // dimensionless
@@ -235,7 +235,7 @@ CONFIG_PARAM_INT("mot_comm_per_max",    12000, 5000,  50000)    // microsecond
 CONFIG_PARAM_INT("mot_spup_st_cp",      100000,10000, 300000)   // microsecond
 CONFIG_PARAM_INT("mot_spup_en_cp",      7000,  1000,  50000);   // microsecond
 CONFIG_PARAM_INT("mot_spup_to_ms",      5000,  100,   9000)     // millisecond (sic!)
-CONFIG_PARAM_INT("mot_spup_blnk_pm",    10,    1,     100)      // permill
+CONFIG_PARAM_INT("mot_spup_blnk_pm",    10,    1,     300)      // permill
 
 static void configure(void)
 {

--- a/firmware/src/motor/realtime/motor_rtctl.c
+++ b/firmware/src/motor/realtime/motor_rtctl.c
@@ -991,6 +991,9 @@ void motor_rtctl_start(float initial_duty_cycle, float target_duty_cycle,
 	motor_timer_set_relative(_state.comm_period / 2);
 
 	chSysEnable();
+
+	printf("Motor: RTCTL Spinup: PWM val %d --> %d\n",
+	       _state.pwm_val_before_spinup, _state.pwm_val_after_spinup);
 }
 
 void motor_rtctl_stop(void)

--- a/firmware/src/motor/realtime/motor_rtctl.c
+++ b/firmware/src/motor/realtime/motor_rtctl.c
@@ -291,7 +291,6 @@ static void stop_from_isr(void)
 	_state.flags = 0;
 	motor_timer_cancel();
 	motor_pwm_set_freewheeling();
-	motor_pwm_set_2_quadrant_mode(false);
 }
 
 static void engage_current_comm_step(void)
@@ -876,7 +875,6 @@ void motor_adc_sample_callback(const struct motor_adc_sample* sample)
 				if (_state.averaged_comm_period <= _params.spinup_end_comm_period) {
 					if (_state.pwm_val >= _state.pwm_val_after_spinup) {
 						_state.flags &= ~FLAG_SPINUP;
-						motor_pwm_set_2_quadrant_mode(false);
 					} else {
 						// Speed up the ramp a bit in order to converge faster
 						_state.pwm_val++;
@@ -958,8 +956,6 @@ void motor_rtctl_start(float initial_duty_cycle, float target_duty_cycle,
 	motor_forced_rotation_detector_reset();
 
 	init_adc_filters();
-
-	motor_pwm_set_2_quadrant_mode(true);
 
 	/*
 	 * Start the background IRQ-driven process
@@ -1076,8 +1072,6 @@ void motor_rtctl_stop(void)
 	irq_primask_enable();
 
 	motor_pwm_set_freewheeling();
-
-	motor_pwm_set_2_quadrant_mode(false);
 }
 
 void motor_rtctl_set_duty_cycle(float duty_cycle)

--- a/firmware/src/motor/realtime/pwm.h
+++ b/firmware/src/motor/realtime/pwm.h
@@ -77,7 +77,8 @@ int motor_pwm_init(void);
  * Note that by default, 4 quadrant mode is selected.
  * Selection of the 2 quadrant mode does not affect the semantics of the driver API calls;
  * however, this mode silently imposes a number of significant restrictions. For example,
- * the minimum PWM value that can be output is silently constrained (typically around ~30%).
+ * the minimum PWM value that can be output is silently constrained (typically around ~20%,
+ * depending on the PWM frequency).
  * These restrictions make the 2Q mode unfit for general purpose use.
  */
 void motor_pwm_set_2_quadrant_mode(bool enable_2q);

--- a/firmware/src/motor/realtime/pwm.h
+++ b/firmware/src/motor/realtime/pwm.h
@@ -68,14 +68,16 @@ enum motor_pwm_phase_manip
 
 /**
  * Initialize the PWM hardware.
- * PWM mode is edge-aligned, the frequency is defined as:
- *      f = pwm_clock / (pwm_top + 1)
- * effective_steps_to_freq = lambda steps: 72e6 / (steps * 2)
- * @param [in] frequency - PWM frequency, Hz
- * @param [in] prevent_full_duty_cycle_bump - Limit the duty cycle range so that there will be no jump near 100%
  * @return 0 on success, anything else if the requested frequency is invalid
  */
 int motor_pwm_init(void);
+
+/**
+ * Switches the PWM driver into the 2 quadrant mode.
+ * Note that by default, 4 quadrant mode is selected.
+ * Selection of the 2 quadrant mode does not affect the semantics of the driver API calls.
+ */
+void motor_pwm_set_2_quadrant_mode(bool enable_2q);
 
 /**
  * ADC converstions are triggered by the PWM hardware, so this function is here
@@ -86,15 +88,6 @@ uint32_t motor_adc_sampling_period_hnsec(void);
  * Direct phase control - for self-testing
  */
 void motor_pwm_manip(const enum motor_pwm_phase_manip command[MOTOR_NUM_PHASES]);
-
-/**
- * Activates 100% duty cycle of specified polarity on all phases.
- * Phase polarity can be defined as:
- *  -1 - negative
- *  0  - floating
- *  1  - positive
- */
-void motor_pwm_energize(const int polarity[MOTOR_NUM_PHASES]);
 
 void motor_pwm_set_freewheeling(void);
 

--- a/firmware/src/motor/realtime/pwm.h
+++ b/firmware/src/motor/realtime/pwm.h
@@ -73,17 +73,6 @@ enum motor_pwm_phase_manip
 int motor_pwm_init(void);
 
 /**
- * Switches the PWM driver into the 2 quadrant mode.
- * Note that by default, 4 quadrant mode is selected.
- * Selection of the 2 quadrant mode does not affect the semantics of the driver API calls;
- * however, this mode silently imposes a number of significant restrictions. For example,
- * the minimum PWM value that can be output is silently constrained (typically around ~20%,
- * depending on the PWM frequency).
- * These restrictions make the 2Q mode unfit for general purpose use.
- */
-void motor_pwm_set_2_quadrant_mode(bool enable_2q);
-
-/**
  * ADC converstions are triggered by the PWM hardware, so this function is here
  */
 uint32_t motor_adc_sampling_period_hnsec(void);

--- a/firmware/src/motor/realtime/pwm.h
+++ b/firmware/src/motor/realtime/pwm.h
@@ -63,7 +63,7 @@ enum motor_pwm_phase_manip
 /**
  * Sanity constraints
  */
-#define MOTOR_PWM_MIN_FREQUENCY   20000
+#define MOTOR_PWM_MIN_FREQUENCY   10000
 #define MOTOR_PWM_MAX_FREQUENCY   40000
 
 /**

--- a/firmware/src/motor/realtime/pwm.h
+++ b/firmware/src/motor/realtime/pwm.h
@@ -64,7 +64,7 @@ enum motor_pwm_phase_manip
  * Sanity constraints
  */
 #define MOTOR_PWM_MIN_FREQUENCY   20000
-#define MOTOR_PWM_MAX_FREQUENCY   50000
+#define MOTOR_PWM_MAX_FREQUENCY   40000
 
 /**
  * Initialize the PWM hardware.
@@ -75,7 +75,10 @@ int motor_pwm_init(void);
 /**
  * Switches the PWM driver into the 2 quadrant mode.
  * Note that by default, 4 quadrant mode is selected.
- * Selection of the 2 quadrant mode does not affect the semantics of the driver API calls.
+ * Selection of the 2 quadrant mode does not affect the semantics of the driver API calls;
+ * however, this mode silently imposes a number of significant restrictions. For example,
+ * the minimum PWM value that can be output is silently constrained (typically around ~30%).
+ * These restrictions make the 2Q mode unfit for general purpose use.
  */
 void motor_pwm_set_2_quadrant_mode(bool enable_2q);
 


### PR DESCRIPTION
Changes:

* Fixed the ADC sampling sequence so that the BEMF signal conditioning circuits have sufficient time to stabilize before the voltages are sampled. This change required me to reduce the BEMF oversampling ratio from 4 to 2 samples per phase per PWM period.
* Fixed the logic of the ADC sampling point computation.
* Configuration parameter changes.
  * Default minimum stable voltage lowered from 3 V to 2.5 V.
  * Default dead time reduced from 700 ns to 600 ns.
  * Initial commutation period during spinup lowered from 200 ms to 100 ms.
  * Parameter for the final commutation period is gone, now it is considered equal to the maximum allowed commutation period.
  * PWM frequency range changed to 10...40 kHz.
* Dynamic blanking time during spinup.
* Zero advance angle during spinup, always.