### PR TITLE
Using averaged_comm_period, improve RPM stability and reduce vibrations

### DIFF
--- a/firmware/src/motor/realtime/motor_rtctl.c
+++ b/firmware/src/motor/realtime/motor_rtctl.c
@@ -1085,7 +1085,7 @@ uint32_t motor_rtctl_get_comm_period_hnsec(void)
 		return 0;
 	}
 
-	const uint32_t val = _state.comm_period;
+	const uint32_t val = _state.averaged_comm_period;
 	return val;
 }
 


### PR DESCRIPTION
This PR takes into account the phase asymmetry averaging done on lines 543 and 902.
Benefits are a more stable rotation in closed loop RPM mode, less torque shocks and thus slightly less vibrations, as well as a more stable measured value returned via CLI stat command and via UAVCAN.