### PR TITLE
Fixed false positive stall detection by raising the ZC failure limit

### DIFF
--- a/firmware/src/motor/realtime/motor_rtctl.c
+++ b/firmware/src/motor/realtime/motor_rtctl.c
@@ -229,7 +229,7 @@ CONFIG_PARAM_INT("mot_tim_cp_min",      600,   100,   50000)    // microsecond
 CONFIG_PARAM_INT("mot_blank_usec",      40,    10,    300)      // microsecond
 CONFIG_PARAM_INT("mot_bemf_win_den",    4,     3,     8)        // dimensionless
 CONFIG_PARAM_INT("mot_bemf_range",      90,    10,    100)      // percent
-CONFIG_PARAM_INT("mot_zc_fails_max",    20,    6,     300)      // dimensionless
+CONFIG_PARAM_INT("mot_zc_fails_max",    100,   6,     300)      // dimensionless
 CONFIG_PARAM_INT("mot_comm_per_max",    4000,  1000,  10000)    // microsecond
 // Spinup settings
 CONFIG_PARAM_INT("mot_spup_st_cp",      100000,10000, 300000)   // microsecond


### PR DESCRIPTION
Context https://forum.zubax.com/t/configuring-orel-for-particular-motor/80

-----
> Please read the section “2.2.6 Rotor stall detection” in the reference manual, and look at the parameter mot_zc_fails_max. The reason we have the zero crossing failure limit is that the early revisions of the firmware were prone to synchronization losses under all but ideal operating conditions and the ZC error counter was used to determine if the motor is likely still spinning or not.
> The modern firmware is much more robust than its early versions (some major improvements were made in the release v2.0 in particular), so the ZC error counter settings should probably be revised.