### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/tools/benchmark/drivers/ardubenchmark.py
+++ b/tools/benchmark/drivers/ardubenchmark.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #
 # Pavel Kirienko <pavel.kirienko@gmail.com>
 #
@@ -59,11 +60,11 @@ class Ardubenchmark:
             try:
                 res = self.poll(handler)
                 if not res:
-                    print 'Ardubenchmark checksum mismatch'
+                    print('Ardubenchmark checksum mismatch')
             except serial.serialutil.SerialException:
                 raise
             except Exception, ex:
-                print 'Ardubenchmark poll failed:', ex
+                print('Ardubenchmark poll failed:', ex)
 
     def stop(self):
         self._keep_going = False

--- a/tools/benchmark/drivers/canas.py
+++ b/tools/benchmark/drivers/canas.py
@@ -3,6 +3,7 @@
 # This is actually a quickly implemented testing tool, it is not intended for real use
 #
 
+from __future__ import print_function
 import threading, struct, time
 from itertools import count
 import pycanbus
@@ -65,7 +66,7 @@ if __name__ == '__main__':
     redund_chan = int(sys.argv[1]) if len(sys.argv) > 1 else 0
     service_code = int(sys.argv[2]) if len(sys.argv) > 2 else 0
     cesc = CanAerospaceEsc('can0', redundancy_channel_id=redund_chan, service_code=service_code)
-    print 'Redundancy channel:', redund_chan, 'Service code:', service_code
+    print('Redundancy channel:', redund_chan, 'Service code:', service_code)
     while 1:
         try:
             dc = float(raw_input('Duty cycle: '))

--- a/tools/benchmark/drivers/pololu_maestro.py
+++ b/tools/benchmark/drivers/pololu_maestro.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #
 # Pavel Kirienko <pavel.kirienko@gmail.com>
 #
@@ -30,11 +31,11 @@ class PololuMaestro:
             finally:
                 termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
             return ch
-        print 'Commands: + for max, - for min'
+        print('Commands: + for max, - for min')
         # Turnigy: http://www.hobbyking.com/hobbyking/store/uploads/981522291X561242X33.pdf
         while 1:
             ch = getchar()
-            print ch
+            print(ch)
             if ch == '+':
                 self.set_ppm_fraction(0, 1.0)
             elif ch == '-':

--- a/tools/benchmark/perform_test_run.py
+++ b/tools/benchmark/perform_test_run.py
@@ -5,6 +5,7 @@
 # ESC testing utility
 #
 
+from __future__ import print_function
 import sys, time, threading, logging
 from functools import partial
 from drivers.ardubenchmark import Ardubenchmark
@@ -76,7 +77,7 @@ def make_driver(name, port=None):
         drv.dispose = lambda: None
 
     if HALF_DUTY_CYCLE:
-        print 'Duty cycle limiting is enabled'
+        print('Duty cycle limiting is enabled')
         drv.set_duty_cycle_unsafe_ = drv.set_duty_cycle
         drv.set_duty_cycle = lambda dc: drv.set_duty_cycle_unsafe_(float(dc) / 2.0)
 

--- a/tools/serial_plot/serial_plot.py
+++ b/tools/serial_plot/serial_plot.py
@@ -3,6 +3,7 @@
 # Pavel Kirienko, 2013 <pavel.kirienko@gmail.com>
 #
 
+from __future__ import print_function
 from PyQt4 import QtGui
 from plot_widget import RealtimePlotWidget
 from serial_reader import SerialReader
@@ -14,7 +15,7 @@ SER_BAUDRATE = 115200
 
 
 def raw_handler(line):
-    print line
+    print(line)
 
 def value_handler(x, values):
     for i,val in enumerate(values):


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.